### PR TITLE
Add way to get amount of higher crafts for farming an item

### DIFF
--- a/src/constants/crops.ts
+++ b/src/constants/crops.ts
@@ -12,6 +12,17 @@ export enum Crop {
 	Seeds = 'WHEAT_SEEDS',
 }
 
+export interface CropCraft {
+	item: string;
+	amount?: number;
+	takes: number;
+	and?: {
+		item: string;
+		amount: number;
+		cost?: number;
+	}[];
+}
+
 export interface CropInfo {
 	name: string;
 	npc: number;
@@ -20,6 +31,7 @@ export interface CropInfo {
 	replenish?: boolean;
 	exportable?: boolean;
 	startingTool: string;
+	crafts: CropCraft[];
 }
 
 export const CROP_INFO: Record<Crop, CropInfo> = {
@@ -29,6 +41,16 @@ export const CROP_INFO: Record<Crop, CropInfo> = {
 		drops: 2,
 		breaks: 2,
 		startingTool: 'CACTUS_KNIFE',
+		crafts: [
+			{
+				item: 'ENCHANTED_CACTUS_GREEN',
+				takes: 160,
+			},
+			{
+				item: 'ENCHANTED_CACTUS',
+				takes: 160 * 160,
+			},
+		],
 	},
 	[Crop.Carrot]: {
 		name: 'Carrot',
@@ -37,6 +59,23 @@ export const CROP_INFO: Record<Crop, CropInfo> = {
 		replenish: true,
 		exportable: true,
 		startingTool: 'THEORETICAL_HOE_CARROT_1',
+		crafts: [
+			{
+				item: 'ENCHANTED_CARROT',
+				takes: 160,
+			},
+			{
+				item: 'ENCHANTED_GOLDEN_CARROT',
+				takes: 128 * 160,
+				and: [
+					{
+						item: 'GOLDEN_CARROT',
+						amount: 32,
+						cost: 15,
+					},
+				],
+			},
+		],
 	},
 	[Crop.CocoaBeans]: {
 		name: 'Cocoa Beans',
@@ -45,12 +84,39 @@ export const CROP_INFO: Record<Crop, CropInfo> = {
 		replenish: true,
 		exportable: true,
 		startingTool: 'COCO_CHOPPER',
+		crafts: [
+			{
+				item: 'ENCHANTED_COCOA',
+				takes: 160,
+			},
+			{
+				item: 'ENCHANTED_COOKIE',
+				takes: 128 * 160,
+				and: [
+					{
+						item: Crop.Wheat,
+						cost: 6,
+						amount: 32,
+					},
+				],
+			},
+		],
 	},
 	[Crop.Melon]: {
 		name: 'Melon',
 		npc: 2,
 		drops: 5,
 		startingTool: 'MELON_DICER',
+		crafts: [
+			{
+				item: 'ENCHANTED_MELON',
+				takes: 160,
+			},
+			{
+				item: 'ENCHANTED_MELON_BLOCK',
+				takes: 160 * 160,
+			},
+		],
 	},
 	[Crop.Mushroom]: {
 		name: 'Mushroom',
@@ -58,6 +124,24 @@ export const CROP_INFO: Record<Crop, CropInfo> = {
 		drops: 1,
 		exportable: true,
 		startingTool: 'FUNGI_CUTTER',
+		crafts: [
+			{
+				item: 'HUGE_MUSHROOM',
+				takes: 9,
+			},
+			{
+				item: 'ENCHANTED_HUGE_MUSHROOM',
+				takes: 9 * 32,
+			},
+			{
+				item: 'HUGE_MUSHROOM_2',
+				takes: 9,
+			},
+			{
+				item: 'ENCHANTED_HUGE_MUSHROOM_2',
+				takes: 9 * 32,
+			},
+		],
 	},
 	[Crop.NetherWart]: {
 		name: 'Nether Wart',
@@ -65,6 +149,16 @@ export const CROP_INFO: Record<Crop, CropInfo> = {
 		drops: 2.5,
 		replenish: true,
 		startingTool: 'THEORETICAL_HOE_WARTS_1',
+		crafts: [
+			{
+				item: 'ENCHANTED_NETHER_STALK',
+				takes: 160,
+			},
+			{
+				item: 'MUTANT_NETHER_STALK',
+				takes: 160 * 160,
+			},
+		],
 	},
 	[Crop.Potato]: {
 		name: 'Potato',
@@ -72,6 +166,16 @@ export const CROP_INFO: Record<Crop, CropInfo> = {
 		drops: 3,
 		replenish: true,
 		startingTool: 'THEORETICAL_HOE_POTATO_1',
+		crafts: [
+			{
+				item: 'ENCHANTED_POTATO',
+				takes: 160,
+			},
+			{
+				item: 'ENCHANTED_BAKED_POTATO',
+				takes: 160 * 160,
+			},
+		],
 	},
 	[Crop.Pumpkin]: {
 		name: 'Pumpkin',
@@ -79,6 +183,16 @@ export const CROP_INFO: Record<Crop, CropInfo> = {
 		drops: 1,
 		exportable: true,
 		startingTool: 'PUMPKIN_DICER',
+		crafts: [
+			{
+				item: 'ENCHANTED_PUMPKIN',
+				takes: 160,
+			},
+			{
+				item: 'POLISHED_PUMPKIN',
+				takes: 160 * 160,
+			},
+		],
 	},
 	[Crop.SugarCane]: {
 		name: 'Sugar Cane',
@@ -86,6 +200,16 @@ export const CROP_INFO: Record<Crop, CropInfo> = {
 		drops: 2,
 		breaks: 2,
 		startingTool: 'THEORETICAL_HOE_CANE_1',
+		crafts: [
+			{
+				item: 'ENCHANTED_SUGAR',
+				takes: 160,
+			},
+			{
+				item: 'ENCHANTED_SUGAR_CANE',
+				takes: 160 * 160,
+			},
+		],
 	},
 	[Crop.Wheat]: {
 		name: 'Wheat',
@@ -93,6 +217,16 @@ export const CROP_INFO: Record<Crop, CropInfo> = {
 		drops: 1,
 		exportable: true,
 		startingTool: 'THEORETICAL_HOE_WHEAT_1',
+		crafts: [
+			{
+				item: 'ENCHANTED_WHEAT',
+				takes: 160,
+			},
+			{
+				item: 'ENCHANTED_HAY_BALE',
+				takes: 160 * 160,
+			},
+		],
 	},
 	[Crop.Seeds]: {
 		name: 'Seeds',
@@ -100,6 +234,16 @@ export const CROP_INFO: Record<Crop, CropInfo> = {
 		drops: 1.5,
 		replenish: true,
 		startingTool: 'THEORETICAL_HOE_WHEAT_1',
+		crafts: [
+			{
+				item: 'ENCHANTED_SEEDS',
+				takes: 160,
+			},
+			{
+				item: 'BOX_OF_SEEDS',
+				takes: 160 * 160,
+			},
+		],
 	},
 };
 

--- a/src/util/ratecalc.test.ts
+++ b/src/util/ratecalc.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { Crop } from '../constants/crops';
-import { calculateDetailedAverageDrops } from './ratecalc.js';
+import { calculateDetailedAverageDrops, getPossibleResultsFromCrops } from './ratecalc.js';
 
 test('Rate calc test', () => {
 	const drops = calculateDetailedAverageDrops({
@@ -15,4 +15,29 @@ test('Rate calc test', () => {
 	expect(drops[Crop.NetherWart].otherCollection['Fermento']).toBe(2);
 	expect(drops[Crop.SugarCane].otherCollection['Fermento']).toBe(2);
 	expect(drops[Crop.Cactus].otherCollection['Fermento']).toBe(2);
+});
+
+test('Possible results - Wheat', () => {
+	const result = getPossibleResultsFromCrops(Crop.Wheat, 26000);
+
+	expect(result[Crop.Wheat].items).toBe(26000);
+	expect(result[Crop.Wheat].cost).toBe(0);
+	expect(result[Crop.Wheat].remainder).toBe(0);
+
+	expect(result['ENCHANTED_WHEAT'].fractionalItems).toBe(162.5);
+	expect(result['ENCHANTED_WHEAT'].cost).toBe(0);
+	expect(result['ENCHANTED_HAY_BALE'].fractionalItems).toBe(1.015625);
+});
+
+test('Possible results - Carrot', () => {
+	const result = getPossibleResultsFromCrops(Crop.Carrot, 26000);
+
+	expect(result[Crop.Carrot].items).toBe(26000);
+	expect(result[Crop.Carrot].cost).toBe(0);
+	expect(result[Crop.Carrot].remainder).toBe(0);
+
+	expect(result['ENCHANTED_CARROT'].fractionalItems).toBe(162.5);
+	expect(result['ENCHANTED_CARROT'].fractionalCost).toBe(0);
+	expect(result['ENCHANTED_GOLDEN_CARROT'].fractionalItems).toBe(1.26953125);
+	expect(result['ENCHANTED_GOLDEN_CARROT'].fractionalCost).toBe(609.375);
 });

--- a/src/util/ratecalc.ts
+++ b/src/util/ratecalc.ts
@@ -250,6 +250,49 @@ export function getNPCProfitFromCrops(crop: Crop, amount: number): number {
 	return npc * amount;
 }
 
+interface PossibleProfit {
+	items: number;
+	fractionalItems: number;
+	remainder: number;
+	cost: number;
+	fractionalCost: number;
+}
+
+export function getPossibleResultsFromCrops(crop: Crop, amount: number): Record<string, PossibleProfit> {
+	const { crafts } = getCropInfo(crop);
+
+	return {
+		[crop]: {
+			items: amount,
+			fractionalItems: amount,
+			remainder: 0,
+			cost: 0,
+			fractionalCost: 0,
+		},
+		...crafts.reduce<Record<string, PossibleProfit>>((acc, curr) => {
+			const items = Math.floor(amount / curr.takes);
+			const remainder = amount % curr.takes;
+			const cost = curr.and?.reduce((sum, curr) => sum + (curr.cost ?? 0) * curr.amount * items, 0);
+
+			const fractionalItems = amount / curr.takes;
+			const fractionalCost = curr.and?.reduce(
+				(sum, curr) => sum + (curr.cost ?? 0) * curr.amount * fractionalItems,
+				0
+			);
+
+			acc[curr.item] = {
+				items,
+				remainder,
+				cost: cost ?? 0,
+				fractionalItems,
+				fractionalCost: fractionalCost ?? 0,
+			};
+
+			return acc;
+		}, {}),
+	};
+}
+
 export function getCropInfo(crop: Crop): CropInfo {
 	return CROP_INFO[crop] ?? {};
 }


### PR DESCRIPTION
Adds a helper method that gives you items that can be crafted from farming each crop. For example, getting the amount of mutant nether wart for X amount of nether wart. This is especially useful for getting the bazaar profits of farming a crop. 

The list of crafts isn't comprehensive, it's just the items you might actually sell.