### PR TITLE
Add collected item ids to ratecalc

### DIFF
--- a/src/constants/specialcrops.ts
+++ b/src/constants/specialcrops.ts
@@ -8,16 +8,19 @@ export enum SpecialCrop {
 
 export const SPECIAL_CROP_INFO = {
 	[SpecialCrop.Cropie]: {
+		id: 'CROPIE',
 		name: 'Cropie',
 		npc: 25_000,
 		rates: [0.0003, 0.0003, 0.0004, 0.0005],
 	},
 	[SpecialCrop.Squash]: {
+		id: 'SQUASH',
 		name: 'Squash',
 		npc: 75_000,
 		rates: [0.0001, 0.0001, 0.0002, 0.0003],
 	},
 	[SpecialCrop.Fermento]: {
+		id: 'FERMENTO',
 		name: 'Fermento',
 		npc: 250_000,
 		rates: [0.00005, 0.00005, 0.00006, 0.00007],

--- a/src/crops/special.ts
+++ b/src/crops/special.ts
@@ -4,11 +4,12 @@ import { MATCHING_SPECIAL_CROP, SPECIAL_CROP_INFO } from '../constants/specialcr
 export function calculateAverageSpecialCrops(blocksBroken: number, crop: Crop, armor: 1 | 2 | 3 | 4) {
 	const type = MATCHING_SPECIAL_CROP[crop];
 
-	const { rates, npc } = SPECIAL_CROP_INFO[type];
+	const { rates, npc, id } = SPECIAL_CROP_INFO[type];
 	const chance = rates[armor - 1] ?? 0;
 	const amount = blocksBroken * chance;
 
 	return {
+		id: id,
 		type: type,
 		amount: amount,
 		npc: npc * amount,

--- a/src/fortune/farmingtool.ts
+++ b/src/fortune/farmingtool.ts
@@ -34,6 +34,10 @@ export class FarmingTool extends UpgradeableBase {
 		return this.colorPrefix + (this.reforge?.name ?? '') + ' ' + this.itemname;
 	}
 
+	public get bountiful() {
+		return this.reforge?.name === REFORGES.bountiful?.name;
+	}
+
 	public declare rarity: Rarity;
 	public declare counter: number | undefined;
 	public declare cultivating: number;

--- a/src/util/names.ts
+++ b/src/util/names.ts
@@ -1,8 +1,8 @@
 import { Crop } from '../constants/crops.js';
 import { RARITY_COLORS, Rarity } from '../constants/reforges.js';
 
-export function getCropDisplayName(crop: Crop) {
-	return cropDisplayNames[crop] ?? 'Unknown Crop';
+export function getCropDisplayName(crop?: Crop | null): string {
+	return (crop ? cropDisplayNames[crop] : null) ?? 'Unknown Crop';
 }
 
 export function getCropFromName(name: string) {

--- a/src/util/ratecalc.test.ts
+++ b/src/util/ratecalc.test.ts
@@ -35,6 +35,21 @@ test('Rate calc test', () => {
 		FERMENTO: 1.68,
 		MUSHROOM_COLLECTION: 48000,
 	});
+
+	expect(drops[Crop.Seeds].items).toStrictEqual({
+		[Crop.Seeds]: 48000,
+		FERMENTO: 1.68,
+		MUSHROOM_COLLECTION: 24000,
+	});
+	expect(drops[Crop.Seeds].otherCollection['Replenish']).toBe(-24000);
+	expect(drops[Crop.Seeds].collection).toBe(48000 + 24000);
+
+	expect(drops[Crop.Wheat].items).toStrictEqual({
+		[Crop.Wheat]: 48000,
+		[Crop.Seeds]: 48000,
+		CROPIE: 12,
+		MUSHROOM_COLLECTION: 24000,
+	});
 });
 
 test('Possible results - Wheat', () => {

--- a/src/util/ratecalc.test.ts
+++ b/src/util/ratecalc.test.ts
@@ -11,10 +11,30 @@ test('Rate calc test', () => {
 	});
 
 	expect(drops[Crop.Wheat].collection).toBe(48_000);
+	expect(drops[Crop.Wheat].npcPrice).toBe(6);
 
 	expect(drops[Crop.NetherWart].otherCollection['Fermento']).toBe(2);
 	expect(drops[Crop.SugarCane].otherCollection['Fermento']).toBe(2);
 	expect(drops[Crop.Cactus].otherCollection['Fermento']).toBe(2);
+
+	expect(drops[Crop.Carrot].items[Crop.Carrot]).toBe(drops[Crop.Carrot].collection - 24000);
+	expect(drops[Crop.Carrot].items).toStrictEqual({
+		[Crop.Carrot]: 120000,
+		CROPIE: 12,
+		MUSHROOM_COLLECTION: 24000,
+	});
+
+	expect(drops[Crop.Melon].items).toStrictEqual({
+		[Crop.Melon]: 426237,
+		SQUASH: 7.2,
+		MUSHROOM_COLLECTION: 24000,
+	});
+
+	expect(drops[Crop.SugarCane].items).toStrictEqual({
+		[Crop.SugarCane]: 96000,
+		FERMENTO: 1.68,
+		MUSHROOM_COLLECTION: 48000,
+	});
 });
 
 test('Possible results - Wheat', () => {

--- a/src/util/ratecalc.ts
+++ b/src/util/ratecalc.ts
@@ -8,6 +8,7 @@ import { BEST_FARMING_TOOLS } from '../items/tools.js';
 
 interface CalculateDropsOptions {
 	farmingFortune?: number;
+	cropFortune?: Record<Crop, number>;
 	blocksBroken: number;
 	dicerLevel?: 1 | 2 | 3;
 	armorPieces?: 1 | 2 | 3 | 4;
@@ -27,13 +28,16 @@ const crops = [
 	Crop.Seeds,
 ] as const;
 
-export function calculateAverageDrops(options: CalculateDropsOptions): Record<Crop, number> {
+type CropFortuneOption = { cropFortune?: Partial<Record<Crop, number>> };
+
+export function calculateAverageDrops(options: CalculateDropsOptions & CropFortuneOption): Record<Crop, number> {
 	const result = {} as Record<Crop, number>;
 
 	for (const crop of crops) {
 		result[crop] = calculateExpectedDrops({
 			crop: crop,
 			...options,
+			farmingFortune: (options.cropFortune?.[crop] ?? 0) + (options.farmingFortune ?? 0),
 		});
 	}
 
@@ -55,13 +59,16 @@ interface DetailedDrops {
 	items: Record<string, number>;
 }
 
-export function calculateDetailedAverageDrops(options: CalculateDetailedDropsOptions): Record<Crop, DetailedDrops> {
+export function calculateDetailedAverageDrops(
+	options: CalculateDetailedDropsOptions & CropFortuneOption
+): Record<Crop, DetailedDrops> {
 	const result = {} as Record<Crop, DetailedDrops>;
 
 	for (const crop of crops) {
 		result[crop] = calculateDetailedDrops({
 			crop: crop,
 			...options,
+			farmingFortune: (options.cropFortune?.[crop] ?? 0) + (options.farmingFortune ?? 0),
 		});
 	}
 
@@ -76,6 +83,7 @@ export function calculateDetailedAverageDrops(options: CalculateDetailedDropsOpt
 		wheat.coinSources['Bountiful (Seeds)'] = seeds.coinSources['Bountiful'] ?? 0;
 	}
 	wheat.npcCoins = Object.values(wheat.coinSources).reduce((a, b) => a + b, 0);
+	wheat.items[Crop.Seeds] = seedCollection;
 
 	// Count mooshroom mushrooms as normal mushroom collection
 	if (options.mooshroom) {


### PR DESCRIPTION
Adds collected item IDs to ratecalc methods, so that it's easier to get bazaar prices for items.